### PR TITLE
Fix Time Class namespace errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ## ProgressBar: A Text Progress Bar Library for Ruby
-
 [![Build Status](https://travis-ci.org/market76/progressbar.png?branch=master)](https://travis-ci.org/market76/progressbar)
 
 Ruby/ProgressBar is a text progress bar library for Ruby.

--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -21,7 +21,7 @@ class ProgressBar
     @current = 0
     @previous = 0
     @finished_p = false
-    @start_time = Time.now
+    @start_time = ::Time.now
     @previous_time = @start_time
     @title_width = 14
     @format = "%-#{@title_width}s %3d%% %s %s"
@@ -86,7 +86,7 @@ private
   end
 
   def transfer_rate
-    bytes_per_second = @current.to_f / (Time.now - @start_time)
+    bytes_per_second = @current.to_f / (::Time.now - @start_time)
     sprintf('%s/s', convert_bytes(bytes_per_second))
   end
 
@@ -107,7 +107,7 @@ private
     if @current == 0
       'ETA:  --:--:--'
     else
-      elapsed = Time.now - @start_time
+      elapsed = ::Time.now - @start_time
       eta = elapsed * @total / @current - elapsed;
       sprintf('ETA: %s', format_time(eta))
     end
@@ -115,7 +115,7 @@ private
 
   # Compute ETA with running average (better suited to long running tasks)
   def eta_running_average
-    now = Time.now
+    now = ::Time.now
 
     # update throughput running average
     if @total > 0 && @eta_previous && @eta_previous_time
@@ -142,7 +142,7 @@ private
   end
 
   def elapsed
-    elapsed = Time.now - @start_time
+    elapsed = ::Time.now - @start_time
     sprintf('Time: %s', format_time(elapsed))
   end
 
@@ -195,7 +195,7 @@ private
       @terminal_width += width - line.length + 1
       show
     end
-    @previous_time = Time.now
+    @previous_time = ::Time.now
   end
 
   def show_if_needed
@@ -209,7 +209,7 @@ private
 
     # Use "!=" instead of ">" to support negative changes
     if cur_percentage != prev_percentage ||
-        Time.now - @previous_time >= 1 || @finished_p
+        ::Time.now - @previous_time >= 1 || @finished_p
       show
     end
   end

--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -10,14 +10,14 @@
 #
 
 class ProgressBar
-  VERSION = "0.20.0"
+  VERSION = '0.20.0'
 
   def initialize (title, total, out = STDERR)
     @title = title
     @total = total
     @out = out
     @terminal_width = 80
-    @bar_mark = "."
+    @bar_mark = '.'
     @current = 0
     @previous = 0
     @finished_p = false
@@ -44,9 +44,9 @@ private
 
   def fmt_bar
     bar_width = do_percentage * @terminal_width / 100
-    sprintf("|%s%s|",
+    sprintf('|%s%s|',
             "\x1B[32m" + @bar_mark * bar_width + "\x1B[32m\x1B[37m",
-            " " *  (@terminal_width - bar_width))
+            ' ' *  (@terminal_width - bar_width))
   end
 
   def fmt_percentage
@@ -63,31 +63,31 @@ private
 
   def fmt_stat_for_file_transfer
     if @finished_p then
-      sprintf("%s %s %s", bytes, transfer_rate, elapsed)
+      sprintf('%s %s %s', bytes, transfer_rate, elapsed)
     else
-      sprintf("%s %s %s", bytes, transfer_rate, eta)
+      sprintf('%s %s %s', bytes, transfer_rate, eta)
     end
   end
 
   def fmt_title
-    @title[0,(@title_width - 1)] + ":"
+    @title[0,(@title_width - 1)] + ':'
   end
 
   def convert_bytes (bytes)
     if bytes < 1024
-      sprintf("%6dB", bytes)
+      sprintf('%6dB', bytes)
     elsif bytes < 1024 * 1000 # 1000kb
-      sprintf("%5.1fKB", bytes.to_f / 1024)
+      sprintf('%5.1fKB', bytes.to_f / 1024)
     elsif bytes < 1024 * 1024 * 1000  # 1000mb
-      sprintf("%5.1fMB", bytes.to_f / 1024 / 1024)
+      sprintf('%5.1fMB', bytes.to_f / 1024 / 1024)
     else
-      sprintf("%5.1fGB", bytes.to_f / 1024 / 1024 / 1024)
+      sprintf('%5.1fGB', bytes.to_f / 1024 / 1024 / 1024)
     end
   end
 
   def transfer_rate
     bytes_per_second = @current.to_f / (Time.now - @start_time)
-    sprintf("%s/s", convert_bytes(bytes_per_second))
+    sprintf('%s/s', convert_bytes(bytes_per_second))
   end
 
   def bytes
@@ -99,17 +99,17 @@ private
     sec = t % 60
     min  = (t / 60) % 60
     hour = t / 3600
-    sprintf("% 3d:%02d:%02d", hour, min, sec);
+    sprintf('% 3d:%02d:%02d', hour, min, sec);
   end
 
   # ETA stands for Estimated Time of Arrival.
   def eta
     if @current == 0
-      "ETA:  --:--:--"
+      'ETA:  --:--:--'
     else
       elapsed = Time.now - @start_time
       eta = elapsed * @total / @current - elapsed;
-      sprintf("ETA: %s", format_time(eta))
+      sprintf('ETA: %s', format_time(eta))
     end
   end
 
@@ -135,15 +135,15 @@ private
 
     if @eta_throughput && @eta_throughput > 0
       eta = (@total - @current) / @eta_throughput;
-      sprintf("ETA: %s", format_time(eta))
+      sprintf('ETA: %s', format_time(eta))
     else
-      "ETA:  --:--:--"
+      'ETA:  --:--:--'
     end
   end
 
   def elapsed
     elapsed = Time.now - @start_time
-    sprintf("Time: %s", format_time(elapsed))
+    sprintf('Time: %s', format_time(elapsed))
   end
 
   def eol
@@ -179,7 +179,7 @@ private
 
   def show
     arguments = @format_arguments.map {|method|
-      method = sprintf("fmt_%s", method)
+      method = sprintf('fmt_%s', method)
       send(method)
     }
     line = sprintf(@format, *arguments)
@@ -218,7 +218,7 @@ public
 
   def clear
     @out.print "\r"
-    @out.print(" " * (get_term_width - 1))
+    @out.print(' ' * (get_term_width - 1))
     @out.print "\r"
   end
 

--- a/progressbar.gemspec
+++ b/progressbar.gemspec
@@ -1,29 +1,29 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path("../lib/progressbar", __FILE__)
+require File.expand_path('../lib/progressbar', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "progressbar"
+  s.name        = 'progressbar'
   s.version     = ProgressBar::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Satoru Takabayashi", "Jose Peleteiro"]
-  s.email       = ["satoru@0xcc.net", "jose@peleteiro.net"]
-  s.homepage    = "http://github.com/peleteiro/progressbar"
-  s.summary     = "Ruby/ProgressBar is a text progress bar library for Ruby."
-  s.description = "Ruby/ProgressBar is a text progress bar library for Ruby. It can indicate progress with percentage, a progress bar, and estimated remaining time."
-  s.license     = "Ruby"
+  s.authors     = ['Satoru Takabayashi', 'Jose Peleteiro']
+  s.email       = ['satoru@0xcc.net', 'jose@peleteiro.net']
+  s.homepage    = 'http://github.com/peleteiro/progressbar'
+  s.summary     = 'Ruby/ProgressBar is a text progress bar library for Ruby.'
+  s.description = 'Ruby/ProgressBar is a text progress bar library for Ruby. It can indicate progress with percentage, a progress bar, and estimated remaining time.'
+  s.license     = 'Ruby'
 
-  s.required_rubygems_version = ">= 1.3.6"
+  s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "minitest", ">= 0"
-  s.add_development_dependency "yard", ">= 0"
-  s.add_development_dependency "rake", ">= 0"
-  s.add_development_dependency "simplecov", ">= 0.3.5"
-  s.add_development_dependency "bluecloth", ">= 0.3.5"
+  s.add_development_dependency 'bundler', '>= 1.0.0'
+  s.add_development_dependency 'minitest', '>= 0'
+  s.add_development_dependency 'yard', '>= 0'
+  s.add_development_dependency 'rake', '>= 0'
+  s.add_development_dependency 'simplecov', '>= 0.3.5'
+  s.add_development_dependency 'bluecloth', '>= 0.3.5'
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
 
-  s.rdoc_options = ["--charset=UTF-8"]
+  s.rdoc_options = ['--charset=UTF-8']
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -10,7 +10,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_bytes
     total = 1024 * 1024
-    pbar = do_make_progress_bar("test(bytes)", total)
+    pbar = do_make_progress_bar('test(bytes)', total)
     pbar.file_transfer_mode
     0.step(total, 2**14) {|x|
       pbar.set(x)
@@ -21,7 +21,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_clear
     total = 100
-    pbar = do_make_progress_bar("test(clear)", total)
+    pbar = do_make_progress_bar('test(clear)', total)
     total.times {
       sleep(SleepUnit)
       pbar.inc
@@ -32,7 +32,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_halt
     total = 100
-    pbar = do_make_progress_bar("test(halt)", total)
+    pbar = do_make_progress_bar('test(halt)', total)
     (total / 2).times {
       sleep(SleepUnit)
       pbar.inc
@@ -42,7 +42,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_inc
     total = 100
-    pbar = do_make_progress_bar("test(inc)", total)
+    pbar = do_make_progress_bar('test(inc)', total)
     total.times {
       sleep(SleepUnit)
       pbar.inc
@@ -51,9 +51,9 @@ class ProgressBarTest < Test::Unit::TestCase
   end
 
   def test_inc_x
-    total = File.size("lib/progressbar.rb")
-    pbar = do_make_progress_bar("test(inc(x))", total)
-    File.new("lib/progressbar.rb").each {|line|
+    total = File.size('lib/progressbar.rb')
+    pbar = do_make_progress_bar('test(inc(x))', total)
+    File.new('lib/progressbar.rb').each {|line|
       sleep(SleepUnit)
       pbar.inc(line.length)
     }
@@ -62,7 +62,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_invalid_set
     total = 100
-    pbar = do_make_progress_bar("test(invalid set)", total)
+    pbar = do_make_progress_bar('test(invalid set)', total)
     begin
       pbar.set(200)
     rescue RuntimeError => e
@@ -72,7 +72,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_set
     total = 1000
-    pbar = do_make_progress_bar("test(set)", total)
+    pbar = do_make_progress_bar('test(set)', total)
     (1..total).find_all {|x| x % 10 == 0}.each {|x|
       sleep(SleepUnit)
       pbar.set(x)
@@ -82,7 +82,7 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_slow
     total = 100000
-    pbar = do_make_progress_bar("test(slow)", total)
+    pbar = do_make_progress_bar('test(slow)', total)
     0.step(500, 1) {|x|
       pbar.set(x)
       sleep(SleepUnit)
@@ -92,13 +92,13 @@ class ProgressBarTest < Test::Unit::TestCase
 
   def test_total_zero
     total = 0
-    pbar = do_make_progress_bar("test(total=0)", total)
+    pbar = do_make_progress_bar('test(total=0)', total)
     pbar.finish
   end
 
   def test_custom_bar_mark
     total = 100
-    pbar = do_make_progress_bar("test(custom)", total)
+    pbar = do_make_progress_bar('test(custom)', total)
     pbar.bar_mark = '='
     total.times {
       sleep(SleepUnit)
@@ -106,10 +106,10 @@ class ProgressBarTest < Test::Unit::TestCase
     }
     pbar.finish
   end
-  
+
   def test_with_block
     total = 100
-    do_make_progress_bar("test(block)", total) do |pbar|
+    do_make_progress_bar('test(block)', total) do |pbar|
       total.times {
         sleep(SleepUnit)
         pbar.inc


### PR DESCRIPTION
We were seeing errors like:
```
NoMethodError: undefined method `now' for ProgressBar::Time:Class
```

This PR should address that issue.